### PR TITLE
Security update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.5
+FROM alpine:3.6
 LABEL maintainer="Marcus Meurs <mail@m4rcu5.nl>" \
-      version="0.1.0"
+      version="0.1.1"
 
 # Add community repo and install packages
-RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.5/community" >> /etc/apk/repositories && \
-    echo "@main http://dl-cdn.alpinelinux.org/alpine/v3.5/main" >> /etc/apk/repositories && \
+RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.6/community" >> /etc/apk/repositories && \
+    echo "@main http://dl-cdn.alpinelinux.org/alpine/v3.6/main" >> /etc/apk/repositories && \
     apk add -U --no-cache \
     pdns-recursor@community && \
     rm -rf /var/cache/apk/* && \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/m4rcu5nl/docker-pdns-recursor-alpine.svg?branch=master)](https://travis-ci.org/m4rcu5nl/docker-pdns-recursor-alpine) [![GitHub issues](https://img.shields.io/github/issues/m4rcu5nl/docker-pdns-recursor-alpine.svg)](https://github.com/m4rcu5nl/docker-pdns-recursor-alpine/issues)  
 docker-pdns-recursor-alpine
 ===========================
-Docker image for PowerDNS Recursor 4.0.4 on Alpine Linux 3.5  
+Docker image for PowerDNS Recursor 4.0.4 on Alpine Linux 3.6  
 Image size: 16.8MB  
   
 Build

--- a/tests/bats/00-docker.bats
+++ b/tests/bats/00-docker.bats
@@ -23,3 +23,9 @@ setup(){
     result="$(docker inspect ${DOCKER_CONTAINER_NAME} -f "{{json .Mounts}}" | jq .[].Destination | grep 'data')"
     [ "$result" = '"/data"' ]
 }
+
+# https://hub.docker.com/r/library/alpine/tags/ shows vulnerability for 3.5 image
+@test "Alpine linux version is version 3.6.x" {
+    result="$(docker exec -ti ${DOCKER_CONTAINER_NAME} cat /etc/alpine-release | cut -d '.' -f 1,2)"
+    [ "$result" = "3.6" ]
+}


### PR DESCRIPTION
Since the Alpine 3.5 Docker images contains a [vulnerability](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-6301) I opted to switch to Alpine 3.6 as base image.