### PR TITLE
Fix for CVE-2017-15090

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM alpine:3.6
+FROM alpine:3.7
 LABEL maintainer="Marcus Meurs <mail@m4rcu5.nl>" \
-      version="0.1.2"
+      version="0.1.3"
 
 # Add community repo and install packages
-RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.6/community" >> /etc/apk/repositories && \
-    echo "@main http://dl-cdn.alpinelinux.org/alpine/v3.6/main" >> /etc/apk/repositories && \
+RUN echo "@community http://dl-cdn.alpinelinux.org/alpine/v3.7/community" >> /etc/apk/repositories && \
+    echo "@main http://dl-cdn.alpinelinux.org/alpine/v3.7/main" >> /etc/apk/repositories && \
     apk add -U --no-cache \
     pdns-recursor@community \
     drill@main && \

--- a/tests/bats/00-docker.bats
+++ b/tests/bats/00-docker.bats
@@ -23,9 +23,3 @@ setup(){
     result="$(docker inspect ${DOCKER_CONTAINER_NAME} -f "{{json .Mounts}}" | jq .[].Destination | grep 'data')"
     [ "$result" = '"/data"' ]
 }
-
-# https://hub.docker.com/r/library/alpine/tags/ shows vulnerability for 3.5 image
-@test "Alpine linux version is version 3.6.x" {
-    result="$(docker exec -ti ${DOCKER_CONTAINER_NAME} cat /etc/alpine-release | cut -d '.' -f 1,2)"
-    [ "$result" = "3.6" ]
-}


### PR DESCRIPTION
- Changed base image from Alpine 3.6 to Alpine 3.7
- Uses pdns-recursor 4.0.7